### PR TITLE
Declare a typedef enum for the operands.

### DIFF
--- a/single-cycle/rtl/controller.sv
+++ b/single-cycle/rtl/controller.sv
@@ -1,10 +1,11 @@
 `default_nettype none
 
+import pa_riscv::*;
+
 module controller
   ( input  var logic [6:0] i_operand
 
   , output var logic       o_regWrite
-  , output var logic [1:0] o_immediateSelect
   , output var logic [1:0] o_aluControl
   , output var logic       o_memWrite
   );
@@ -12,43 +13,26 @@ module controller
   // Decode operand to determine if the instruction involves a register write.
   always_comb
     case (i_operand)
-      // LW
-      7'b0000011: o_regWrite = '1;
-      // SW
-      7'b0100011: o_regWrite = '0;
-      default:    o_regWrite = 'x;
-    endcase
-
-  // Decode operand to determine which bits of the instruction represent the
-  // immediate field.
-  always_comb
-    case (i_operand)
-      // LW
-      7'b0000011: o_immediateSelect = 2'b00;
-      // SW
-      7'b0100011: o_immediateSelect = 2'b01;
-      default:    o_immediateSelect = 2'bxx;
+      I:       o_regWrite = '1;
+      S:       o_regWrite = '0;
+      default: o_regWrite = 'x;
     endcase
 
   // Decode operand to determine the logical operation performed by the ALU for
   // the instruction.
   always_comb
     case (i_operand)
-      // LW
-      7'b0000011: o_aluControl = 2'b00;
-      // SW
-      7'b0100011: o_aluControl = 2'b00;
-      default:    o_aluControl = 2'bxx;
+      I:       o_aluControl = 2'b00;
+      S:       o_aluControl = 2'b00;
+      default: o_aluControl = 2'bxx;
     endcase
 
   // Decode operand to determine if the instruction involves a memory write.
   always_comb
     case (i_operand)
-      // LW
-      7'b0000011: o_memWrite = '0;
-      // SW
-      7'b0100011: o_memWrite = '1;
-      default:    o_memWrite = 'x;
+      I:       o_memWrite = '0;
+      S:       o_memWrite = '1;
+      default: o_memWrite = 'x;
     endcase
 
   endmodule

--- a/single-cycle/rtl/extend.sv
+++ b/single-cycle/rtl/extend.sv
@@ -1,8 +1,9 @@
 `default_nettype none
 
+import pa_riscv::*;
+
 module extend
   ( input  var logic [31:0] i_instruction
-  , input  var logic [1:0]  i_immediateSelect
 
   , output var logic [31:0] o_immediateExtended
   );
@@ -10,12 +11,10 @@ module extend
   // Decode opcode to find the immediate bits to concatenate, and sign extend
   // to 32 bits.
   always_comb
-    case (i_immediateSelect)
-      // LW
-      2'b00:   o_immediateExtended =
+    case (i_instruction[6:0])
+      I:       o_immediateExtended =
                 {{20{i_instruction[31]}}, i_instruction[31:20]};
-      // SW
-      2'b01:   o_immediateExtended =
+      S:       o_immediateExtended =
                 {{20{i_instruction[31]}}, i_instruction[31:25], i_instruction[11:7]};
       default: o_immediateExtended = 32'bx;
     endcase

--- a/single-cycle/rtl/pa_riscv.sv
+++ b/single-cycle/rtl/pa_riscv.sv
@@ -1,0 +1,17 @@
+`ifndef PA_RISCV
+  `define PA_RISCV
+
+`default_nettype none
+
+package pa_riscv;
+
+  typedef enum logic [6:0]
+  { I = 7'b0000011
+  , S = 7'b0100011
+  } ty_INSTRUCTION_TYPE;
+
+endpackage
+
+`resetall
+
+`endif

--- a/single-cycle/rtl/singleCycleTop_elaborated.sv
+++ b/single-cycle/rtl/singleCycleTop_elaborated.sv
@@ -27,13 +27,11 @@ module singleCycleTop_elaborated
   logic       regWrite;
   logic       memWrite;
   logic [1:0] aluControl;
-  logic [1:0] immediateSelect;
 
   controller u_controller
   ( .i_operand         (operand)
 
   , .o_regWrite        (regWrite)        // Write to register file.
-  , .o_immediateSelect (immediateSelect) // Extract immediate bits of instruction.
   , .o_aluControl      (aluControl)      // ALU logical operation.
   , .o_memWrite        (memWrite)        // Write to memory.
   );
@@ -73,7 +71,6 @@ module singleCycleTop_elaborated
   // Extract the immediate from the instruction and sign extend to 32 bits.
   extend u_extend
   ( .i_instruction       (instruction)
-  , .i_immediateSelect   (immediateSelect)
 
   , .o_immediateExtended (addressOffset)
   );


### PR DESCRIPTION
- Operands are decoded in package.
- Makes it look tidier.
- Easier to make changes.
- Immediate select no longer necessary, operand is decoded from instruction.